### PR TITLE
Add get_callee tool 

### DIFF
--- a/bridge_mcp_ghidra.py
+++ b/bridge_mcp_ghidra.py
@@ -627,6 +627,19 @@ def set_bytes(address: str, bytes_hex: str) -> str:
     """
     return safe_post("set_bytes", {"address": address, "bytes": bytes_hex})
 
+@mcp.tool()
+def get_callee(address: str) -> list:
+    """
+    Get the functions called by the function at the specified address.
+    
+    Args:
+        address: The address within the function.
+        
+    Returns:
+        A list of called functions.
+    """
+    return safe_get("get_callee", {"address": address})
+
 def main():
     parser = argparse.ArgumentParser(description="MCP server for Ghidra")
     parser.add_argument("--ghidra-server", type=str, default=DEFAULT_GHIDRA_SERVER,

--- a/src/main/java/com/lauriewired/handlers/get/GetCallee.java
+++ b/src/main/java/com/lauriewired/handlers/get/GetCallee.java
@@ -1,0 +1,68 @@
+package com.lauriewired.handlers.get;
+
+import com.lauriewired.handlers.Handler;
+import com.sun.net.httpserver.HttpExchange;
+import ghidra.framework.plugintool.PluginTool;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.Program;
+import ghidra.util.task.TaskMonitor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.lauriewired.util.ParseUtils.parseQueryParams;
+import static com.lauriewired.util.ParseUtils.sendResponse;
+import static ghidra.program.util.GhidraProgramUtilities.getCurrentProgram;
+
+public class GetCallee extends Handler {
+    public GetCallee(PluginTool tool) {
+        super(tool, "/get_callee");
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        Map<String, String> qparams = parseQueryParams(exchange);
+        String addressStr = qparams.get("address");
+        sendResponse(exchange, getCallee(addressStr));
+    }
+
+    private String getCallee(String addressStr) {
+        if (addressStr == null) {
+            return "Missing address parameter";
+        }
+
+        try {
+            Program currentProgram = getCurrentProgram(tool);
+            if (currentProgram == null) {
+                return "No active program";
+            }
+
+            Address address = currentProgram.getAddressFactory().getAddress(addressStr);
+            Function fn = currentProgram.getFunctionManager().getFunctionContaining(address);
+
+            if (fn == null) {
+                return "No function at the specified address";
+            }
+
+            Set<Function> callees = fn.getCalledFunctions(TaskMonitor.DUMMY);
+            if (callees.isEmpty()) {
+                return "(no callees)";
+            }
+
+            List<String> calleeList = new ArrayList<>();
+            for (Function callee : callees) {
+                calleeList.add(String.format("%s @ %s", callee.getName(true), callee.getEntryPoint()));
+            }
+            Collections.sort(calleeList, String.CASE_INSENSITIVE_ORDER);
+
+            return String.join("\n", calleeList);
+        } catch (Exception e) {
+            return "Error processing request: " + e.getMessage();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a new feature to GhidraMCP that returns the **callees** of a function at a given address.

- **Python (MCP client):** Exposes `get_callee(address: str)` as an `@mcp.tool()` so clients can request callees from Ghidra.
- **Ghidra (plugin/handler):** Introduces a `/get_callee` endpoint handled by `GetCallee`, which enumerates the called functions of the function containing the specified address and returns them.

## Motivation
During reverse engineering, it’s often necessary to quickly inspect **outgoing calls** from a function. Enabling retrieval through the MCP bridge will aid the implementation of AI agents

## Changes
### Python
- Add `get_callee(address: str)` decorated with `@mcp.tool()`.
- Internally calls the bridge with `safe_get("get_callee", {"address": address})`.

### Ghidra
- Add `com.lauriewired.handlers.get.GetCallee`:
  - Registers the path `/get_callee`.
  - Reads the `address` query parameter.
  - Resolves the function at that address.
  - Enumerates callees via `getCalledFunctions(TaskMonitor.DUMMY)`.
  - Formats results as `"functionName @ entryPoint"` lines joined by `\n`.
  - Returns meaningful error messages for invalid cases.

<img width="488" height="835" alt="image" src="https://github.com/user-attachments/assets/51174ad2-3d61-4412-afd0-cc699654e02c" />